### PR TITLE
moving of JK games to s.yaml pt1

### DIFF
--- a/originals/s.yaml
+++ b/originals/s.yaml
@@ -522,10 +522,52 @@
 - name: 'Star Wars Jedi Knight: Dark Forces II'
   external:
     wikipedia: 'Star Wars Jedi Knight: Dark Forces II'
+    platform:
+    - Windows
   meta:
     genre:
+    - Fighting
     - FPS
+    - TPS
     theme:
+    - Fantasy
+    - Sci-Fi
+    
+- name: 'Star Wars: Jedi Knight II: Jedi Outcast'
+  external:
+    wikipedia: 'Star Wars: Jedi Knight II: Jedi Outcast'
+  platform:
+  - GameCube
+  - Nintendo Switch
+  - OSX
+  - PlayStation 4
+  - Windows
+  - Xbox
+  meta:
+    genre:
+    - Fighting
+    - FPS
+    - TPS
+    theme:
+    - Fantasy
+    - Sci-Fi
+    
+- name: 'Star Wars: Jedi Knight: Jedi Academy'
+  external:
+    wikipedia: 'Star Wars: Jedi Knight: Jedi Academy'
+  platform:
+  - Nintendo Switch
+  - OSX
+  - PlayStation 4
+  - Windows
+  - Xbox
+  meta:
+    genre:
+    - Fighting
+    - FPS
+    - TPS
+    theme:
+    - Fantasy
     - Sci-Fi
 
 - name: 'Star Wars: Knights of the Old Republic'


### PR DESCRIPTION
This is a part 1 of moving the Raven Software Jedi Knight games over to s.yaml out of consistency and ease of finding. As a bonus, the original Jedi Knight's info has also been changed to fit with the extended information added to the Raven Software Jedi Knight games.